### PR TITLE
Add method to override sms receiver

### DIFF
--- a/src/Channels/AliyunSmsChannel.php
+++ b/src/Channels/AliyunSmsChannel.php
@@ -17,6 +17,11 @@ class AliyunSmsChannel
     protected $signName;
 
     /**
+     * @var string|null;
+     */
+    protected static $alwaysTo;
+
+    /**
      * Create a new Aliyun SMS channel instance.
      *
      * @param string $signName
@@ -24,6 +29,11 @@ class AliyunSmsChannel
     public function __construct(string $signName)
     {
         $this->signName = $signName;
+    }
+
+    public static function alwaysTo($alwaysTo)
+    {
+        static::$alwaysTo = $alwaysTo;
     }
 
     /**
@@ -41,6 +51,10 @@ class AliyunSmsChannel
     {
         if (!$to = $notifiable->routeNotificationFor('aliyun', $notification)) {
             return null;
+        }
+
+        if (static::$alwaysTo !== null) {
+            $to = static::$alwaysTo;
         }
 
         /** @var AliyunMessage $message */

--- a/tests/NotificationAliyunSmsChannelTest.php
+++ b/tests/NotificationAliyunSmsChannelTest.php
@@ -13,6 +13,49 @@ use Orchestra\Testbench\TestCase;
 
 class NotificationAliyunSmsChannelTest extends TestCase
 {
+    public function testAlwaysToWorks()
+    {
+        $notification = new NotificationAliyunChannelTestNotification;
+        $notifiable = new NotificationAliyunChannelTestNotifiable;
+        $alwaysTo = '11223344';
+        AliyunSmsChannel::alwaysTo($alwaysTo);
+
+        $result = $this->mock(Result::class, function (MockInterface $mock) {
+
+            $mock->shouldReceive('get')
+                ->with('Code')
+                ->andReturn('OK');
+
+        });
+
+        $this->mock(SendSms::class, function (MockInterface $mock) use ($alwaysTo, $result) {
+
+            $mock->shouldReceive('withSignName')
+                 ->andReturn($mock);
+
+            $mock->shouldReceive('withPhoneNumbers')
+                 ->andReturnUsing(function ($phoneNumbers) use ($alwaysTo, $mock) {
+                     $this->assertEquals($alwaysTo, $phoneNumbers);
+
+                     return $mock;
+                 });
+
+            $mock->shouldReceive('withTemplateParam')
+                 ->andReturn($mock);
+
+            $mock->shouldReceive('withTemplateCode')
+                 ->andReturn($mock);
+
+            $mock->shouldReceive('request')
+                ->andReturn($result);
+
+        });
+
+        $channel = new AliyunSmsChannel('sign-name');
+        $channel->send($notifiable, $notification);
+
+        AliyunSmsChannel::alwaysTo(null);
+    }
 
     public function testSmsIsSentViaAliyun()
     {


### PR DESCRIPTION
This will avoid sending sms to real customers in a staging environment。

```php

use GrantHolle\Notifications\Channels\AliyunSmsChannel;

class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        if (!app()->environment('production')) {
            AliyunSmsChannel::alwaysTo('your-phone-number');
        }
    }
}
```